### PR TITLE
formatting, improved update, chpst for runit, transcoding dir, and travis-ci linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+addons:
+  apt:
+    sources:
+      - debian-sid
+    packages:
+      - shellcheck
+script:
+  - shellcheck --version
+  - find . -type f -name '*.sh' | while read file; do echo "Linting $file"; shellcheck $file || exit 1; done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,20 @@
 FROM linuxserver/baseimage
 MAINTAINER Stian Larsen <lonixx@gmail.com>
 
-# Install Plex
 RUN apt-get -q update && \
-VERSION=$(curl -s https://tools.linuxserver.io/latest-plex.json| grep "version" | cut -d '"' -f 4) && \
 apt-get install -qy dbus gdebi-core avahi-daemon wget && \
-wget -P /tmp "https://downloads.plexapp.com/plex-media-server/$VERSION/plexmediaserver_${VERSION}_amd64.deb" && \
-gdebi -n /tmp/plexmediaserver_${VERSION}_amd64.deb && \
-rm -f /tmp/plexmediaserver_${VERSION}_amd64.deb && \
+VERSION=$(curl -s https://tools.linuxserver.io/latest-plex.json| grep "version" | cut -d '"' -f 4) && \
+wget -t 12 -w 5 --retry-connrefused -P /tmp "https://downloads.plexapp.com/plex-media-server/$VERSION/plexmediaserver_${VERSION}_amd64.deb" && \
+gdebi -n "/tmp/plexmediaserver_${VERSION}_amd64.deb" && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-
-
-#Adding Custom files
 ADD init/ /etc/my_init.d/
 ADD services/ /etc/service/
 RUN chmod -v +x /etc/service/*/run
 RUN chmod -v +x /etc/my_init.d/*.sh
-# Define /config in the configuration file not using environment variables
+
 ADD plexmediaserver /defaults/plexmediaserver
 
-#Mappings and ports
 VOLUME /config
 EXPOSE 32400

--- a/LICENSE
+++ b/LICENSE
@@ -672,4 +672,3 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
-

--- a/README.md
+++ b/README.md
@@ -12,22 +12,24 @@ The [LinuxServer.io](http://linuxserver.io) team brings you another quality cont
 
 ```
 docker create \
-	--name=plex \ 
-	--net=host \
-	-e VERSION="plexpass" \
-	-e PUID=<UID> -e PGID=<GID> \
-	-v </path/to/library>:/config \
-	-v <path/to/tvseries>:/data/tvshows \
-	-v </path/to/movies>:/data/movies \
-	linuxserver/plex
+  --name=plex \
+  --net=host \
+  -e VERSION="plexpass" \
+  -e PUID=<UID> -e PGID=<GID> \
+  -v </path/to/library>:/config \
+  -v </path/to/transcode>:/transcode \
+  -v <path/to/tvseries>:/data/tvshows \
+  -v </path/to/movies>:/data/movies \
+  linuxserver/plex
 ```
 
 **Parameters**
 
 * `--net=host` - Shares host networking with container, **required**.
 * `-v /config` - Plex library location. *This can grow very large, 50gb+ is likely for a large collection.*
+* `-v /transcode` - Transcode directory to offload heavy writes in a docker container.
 * `-v /data/xyz` - Media goes here. Add as many as needed e.g. `/data/movies`, `/data/tv`, etc.
-* `-e VERSION` - Set this to a full version number if you want to use a spesific version e.g. `0.9.12.4.1192-9a47d21`, or set it to `plexpass` or `latest`
+* `-e VERSION` - Set this to a full version number if you want to use a specific version e.g. `0.9.12.4.1192-9a47d21`, or set it to `plexpass` or `latest`
 * `-e PGID` for for GroupID - see below for explanation
 * `-e PUID` for for UserID - see below for explanation
 
@@ -44,10 +46,12 @@ Part of what makes our containers work so well is by allowing you to specify you
 
 ## Changelog
 
++ **17.09.2015:** Added travis-ci support and linting for shell files.
++ **17.09.2015:** Formatting cleanup. Improved update process. Switched to using chpst for runit. Transcoding moved out of /tmp to /transcode.
 + **17.09.2015:** Changed to run chmod only once
-+ **19.09.2015:** Plex updateed theyre download servers from http to https
-+ **28.08.2015:** Removed plexpass from rutine, and now uses VERSION as a combination fix.
-+ **18.07.2015:** Moved autoupdate to be hosted by linuxserver.io and implented bugfix thanks to ljm42.
-+ **09.07.2015:** Now with ability to pick static versionnumber.
++ **16.09.2015:** Plex updated their download servers from http to https
++ **28.08.2015:** Removed plexpass from routine, and now uses VERSION as a combination fix.
++ **18.07.2015:** Moved autoupdate to be hosted by linuxserver.io and implemented bugfix thanks to ljm42.
++ **09.07.2015:** Now with ability to pick static version number.
 + **08.07.2015:** Now with autoupdates. (Hosted by fanart.tv)
 + **03.07.2015:** Fixed a mistake that allowed plex to run as user plex rather than abc (99:100). Thanks to double16 for spotting this.

--- a/init/10_dbus.sh
+++ b/init/10_dbus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -e /var/run/dbus/pid ]; then rm -f /var/run/dbus/pid; fi
+[ -e /var/run/dbus/pid ] && rm -f /var/run/dbus/pid
 mkdir -p /var/run/dbus
 chown messagebus:messagebus /var/run/dbus
 dbus-uuidgen --ensure

--- a/init/90_chown_plex_owned_files.sh
+++ b/init/90_chown_plex_owned_files.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-if [ ! -d "/config/Library" ]; then
-  mkdir /config/Library
-  chown abc:abc /config/Library
-fi
+[ ! -d "/config/Library" ] && mkdir /config/Library
+[ ! -d "/transcode" ] && mkdir /transcode && chown abc:abc /transcode
 
-if [ ! -f "/config/Library/linuxserver-chown.lock" ]; then
-  find /config/Library ! \( -user abc -a -group root \) -print0 | xargs -0 chown abc:root
-  touch /config/Library/linuxserver-chown.lock
+# this is to allow users to import an existing plex install
+if [ ! -f "/config/Library/linuxserverio-chown.lock" ]; then
+  find /config/Library ! \( -user abc -a -group abc \) -print0 | xargs -0 chown abc:abc
+  touch /config/Library/linuxserverio-chown.lock
 fi

--- a/plexmediaserver
+++ b/plexmediaserver
@@ -7,7 +7,7 @@ PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS=6
 PLEX_MEDIA_SERVER_MAX_STACK_SIZE=3000
 
 # where the mediaserver should store the transcodes
-PLEX_MEDIA_SERVER_TMPDIR=/tmp
+PLEX_MEDIA_SERVER_TMPDIR=/transcode
 
 # uncomment to set it to something else
 PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="/config/Library/Application Support"

--- a/services/plex/run
+++ b/services/plex/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec /sbin/setuser abc /usr/sbin/start_pms
+exec /usr/bin/chpst -u abc /usr/sbin/start_pms


### PR DESCRIPTION
Formatting cleanup. Improved update process. Switched to using chpst for runit. Transcoding moved out of /tmp to /transcode. Added travis-ci support and linting for shell files.