### PR TITLE
Removed extra 'v' on line 21

### DIFF
--- a/init/30_update_plex.sh
+++ b/init/30_update_plex.sh
@@ -18,7 +18,7 @@ PLEX_TOKEN=$( sed -n 's/.*PlexOnlineToken="//p' "/config/Library/Application Sup
 [ "$PLEXPASS" ] && echo "PLEXPASS is deprecated, please use VERSION"
 if [[ -z $VERSION && "$PLEXPASS" == "1" || $VERSION = "plexpass" ]]; then echo "VERSION=plexpass is depricated please use version latest"; fi
 
-v
+
 #Start update rutine
 
 


### PR DESCRIPTION
This pull fixes the `/etc/my_init.d/30_update_plex.sh: line 21: v: command not found` error when the container is started.