### PR TITLE
reseting group to use the group specified by PGID

### DIFF
--- a/init/90_chown_plex_owned_files.sh
+++ b/init/90_chown_plex_owned_files.sh
@@ -6,6 +6,6 @@ if [ ! -d "/config/Library" ]; then
 fi
 
 if [ ! -f "/config/Library/linuxserver-chown.lock" ]; then
-  find /config/Library ! \( -user abc -a -group root \) -print0 | xargs -0 chown abc:root
+  find /config/Library ! \( -user abc -a -group abc \) -print0 | xargs -0 chown abc:abc
   touch /config/Library/linuxserver-chown.lock
 fi


### PR DESCRIPTION
somewhere along the way, the group was reset to root from abc - propose setting it back