### PR TITLE
Additional sanity check in init file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
  apt-get install -y \
 	avahi-daemon \
 	dbus \
+	debsums \
 	wget && \
 
 # install plex

--- a/root/etc/cont-init.d/50-plex-update
+++ b/root/etc/cont-init.d/50-plex-update
@@ -14,6 +14,17 @@ rm -f /tmp/plexmediaserver.deb
 exit 0
 fi
 
+# test if plex is modified and try re-pulling latest if it is
+plexmodified=`debsums -s 2>&1 | grep debsums | cut -f6 -d" " | sort -u | grep plexmediaserver | wc -l`
+if [[ $plexmodified -gt 0 ]]; then
+echo "for some reason plex appear to be modified, pulling a new copy and exiting out of update script"
+curl -o /tmp/plexmediaserver.deb -L \
+       	"${PLEX_INSTALL}" && \
+dpkg -i --force-confold /tmp/plexmediaserver.deb
+rm -f /tmp/plexmediaserver.deb
+exit 0
+fi
+
 # set no update message
 [[ -e /tmp/no-version.nfo ]] && \
        	rm /tmp/no-version.nfo

--- a/root/etc/cont-init.d/50-plex-update
+++ b/root/etc/cont-init.d/50-plex-update
@@ -5,9 +5,7 @@
        	cp /defaults/plexmediaserver /etc/default/plexmediaserver
 
 # test if plex is installed and try re-pulling latest if not
-if (dpkg --get-selections plexmediaserver | grep -wq "install"); then
-:
-else
+if (!(dpkg --get-selections plexmediaserver | grep -wq "install")); then
 echo "for some reason plex doesn't appear to be installed, pulling a new copy and exiting out of update script"
 curl -o /tmp/plexmediaserver.deb -L \
        	"${PLEX_INSTALL}" && \


### PR DESCRIPTION
Added a new check to verify the integrity of the plexmediaserver files installed in the container. This should ensure that a proper deb package is pulled and installed if for some reason the files have been tampered with.