### PR TITLE
use plex env variables, usermod home folder of abc to /app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ MAINTAINER Stian Larsen, sparklyballs
 ENV PLEX_INSTALL="https://plex.tv/downloads/latest/1?channel=8&build=linux-ubuntu-x86_64&distro=ubuntu"
 
 # global environment settings
-ENV DEBIAN_FRONTEND="noninteractive"
-ENV HOME="/config"
-ENV PLEX_DOWNLOAD="https://downloads.plex.tv/plex-media-server"
+ENV DEBIAN_FRONTEND="noninteractive" \
+PLEX_DOWNLOAD="https://downloads.plex.tv/plex-media-server" \
+PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="/config/Library/Application Support" \
+PLEX_MEDIA_SERVER_HOME="/usr/lib/plexmediaserver" \
+PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS="6"
 
 # install packages
 RUN \
@@ -22,6 +24,9 @@ RUN \
 	/tmp/plexmediaserver.deb -L \
 	"${PLEX_INSTALL}" && \
  dpkg -i /tmp/plexmediaserver.deb && \
+
+# change abc home folder to fix plex hanging at runtime with usermod
+ usermod -d /app abc && \
 
 # cleanup
  apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ PLEX_INSTALL="https://plex.tv/downloads/latest/1?channel=8&build=linux-ubuntu-x8
 PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="/config/Library/Application Support" \
 PLEX_MEDIA_SERVER_HOME="/usr/lib/plexmediaserver" \
 PLEX_MEDIA_SERVER_INFO_DEVICE=docker \
-PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS="6"
+PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS="6" \
+LD_LIBRARY_PATH="/usr/lib/plexmediaserver:$LD_LIBRARY_PATH"
 
 # install packages
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM lsiobase/xenial
 MAINTAINER Stian Larsen, sparklyballs
 
-# package version
-ENV PLEX_INSTALL="https://plex.tv/downloads/latest/1?channel=8&build=linux-ubuntu-x86_64&distro=ubuntu"
 
 # global environment settings
 ENV DEBIAN_FRONTEND="noninteractive" \
 PLEX_DOWNLOAD="https://downloads.plex.tv/plex-media-server" \
+PLEX_INSTALL="https://plex.tv/downloads/latest/1?channel=8&build=linux-ubuntu-x86_64&distro=ubuntu" \
 PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="/config/Library/Application Support" \
 PLEX_MEDIA_SERVER_HOME="/usr/lib/plexmediaserver" \
+PLEX_MEDIA_SERVER_INFO_DEVICE=docker \
 PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS="6"
 
 # install packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="/config/Library/Application Support" 
 PLEX_MEDIA_SERVER_HOME="/usr/lib/plexmediaserver" \
 PLEX_MEDIA_SERVER_INFO_DEVICE=docker \
 PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS="6" \
+PLEX_MEDIA_SERVER_USER=abc \
 LD_LIBRARY_PATH="/usr/lib/plexmediaserver:$LD_LIBRARY_PATH"
 
 # install packages

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Valid settings for VERSION are:-
 
 ## Versions
 
++ **11.01.17:** Use Plex environemt variables from pms docker,
+change abc home folder to /app to alleviate usermod chowning library folder by default (thanks gbooker, plexinc).
 + **03.01.17:** Use case insensitive version variable matching rather than export and make lowercase.
 + **17.10.16:** Allow use of uppercase version variable
 + **01.10.16:** Add TZ info to README.

--- a/root/etc/cont-init.d/40-chown-files
+++ b/root/etc/cont-init.d/40-chown-files
@@ -1,9 +1,9 @@
 #!/usr/bin/with-contenv bash
 
 # create folders
-if [[ ! -d ${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR} ]]; then \
+if [ ! -d "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}" ]; then \
 mkdir -p "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
-chown -R abc:abc "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
+chown -R abc:abc /config
 fi
 
 # check Library permissions

--- a/root/etc/cont-init.d/40-chown-files
+++ b/root/etc/cont-init.d/40-chown-files
@@ -1,12 +1,16 @@
 #!/usr/bin/with-contenv bash
 
 # check for Library existence and permissions
-if [ ! -d "/config/Library" ]; then
-  mkdir -p /config/Library
-  chown abc:abc /config/Library
-elif [ ! "$(stat -c %u /config/Library)" = "$PUID" ]; then
-  echo "Change in ownership detected, please be patient while we chown existing files"
-  echo "This could take some time"
-  chown abc:abc -R \
-	/config/Library
+if [ ! -d "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}" ]; then
+	mkdir -p "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
+	chown abc:abc "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
+elif [ ! "$(stat -c %u ${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR})" = "$PUID" ]; then
+	echo "Change in ownership detected, please be patient while we chown existing files"
+	echo "This could take some time"
+	chown abc:abc -R \
+	"${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
 fi
+
+chown abc:abc \
+	/config \
+	/config/*

--- a/root/etc/cont-init.d/40-chown-files
+++ b/root/etc/cont-init.d/40-chown-files
@@ -1,16 +1,17 @@
 #!/usr/bin/with-contenv bash
 
-# check for Library existence and permissions
-if [ ! -d "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}" ]; then
-	mkdir -p "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
-	chown abc:abc "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
-elif [ ! "$(stat -c %u "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}")" = "$PUID" ]; then
+# create folders
+if [[ ! -d ${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR} ]]; then \
+mkdir -p "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
+chown -R abc:abc "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
+fi
+
+# check Library permissions
+PUID=${PUID:-911}
+if [ ! "$(stat -c %u /config/Library)" = "$PUID" ]; then
 	echo "Change in ownership detected, please be patient while we chown existing files"
 	echo "This could take some time"
 	chown abc:abc -R \
-	"${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
+	/config/Library
 fi
 
-chown abc:abc \
-	/config \
-	/config/*

--- a/root/etc/cont-init.d/40-chown-files
+++ b/root/etc/cont-init.d/40-chown-files
@@ -4,7 +4,7 @@
 if [ ! -d "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}" ]; then
 	mkdir -p "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
 	chown abc:abc "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}"
-elif [ ! "$(stat -c %u ${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR})" = "$PUID" ]; then
+elif [ ! "$(stat -c %u "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}")" = "$PUID" ]; then
 	echo "Change in ownership detected, please be patient while we chown existing files"
 	echo "This could take some time"
 	chown abc:abc -R \

--- a/root/etc/cont-init.d/40-chown-files
+++ b/root/etc/cont-init.d/40-chown-files
@@ -14,4 +14,3 @@ if [ ! "$(stat -c %u /config/Library)" = "$PUID" ]; then
 	chown abc:abc -R \
 	/config/Library
 fi
-

--- a/root/etc/cont-init.d/40-chown-files
+++ b/root/etc/cont-init.d/40-chown-files
@@ -14,3 +14,8 @@ if [ ! "$(stat -c %u /config/Library)" = "$PUID" ]; then
 	chown abc:abc -R \
 	/config/Library
 fi
+
+# permissions (non-recursive) on config root and folders
+chown abc:abc \
+	/config \
+	/config/*

--- a/root/etc/cont-init.d/50-plex-update
+++ b/root/etc/cont-init.d/50-plex-update
@@ -1,9 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-# copy config on first run, regardless of update status
-[[ ! -e /etc/default/plexmediaserver ]] && \
-       	cp /defaults/plexmediaserver /etc/default/plexmediaserver
-
 # test if plex is installed and try re-pulling latest if not
 if (dpkg --get-selections plexmediaserver | grep -wq "install"); then
 :
@@ -117,6 +113,3 @@ else
 dpkg -i --force-confold /tmp/plexmediaserver_"${REMOTE_VERSION}"_amd64.deb
 rm -f /tmp/plexmediaserver_*.deb
 fi
-
-# recopy config file
-cp /defaults/plexmediaserver /etc/default/plexmediaserver

--- a/root/etc/services.d/avahi/run
+++ b/root/etc/services.d/avahi/run
@@ -6,4 +6,3 @@ done
 
 echo "Starting Avahi daemon"
 exec avahi-daemon --no-chroot
-

--- a/root/etc/services.d/dbus/run
+++ b/root/etc/services.d/dbus/run
@@ -2,4 +2,3 @@
 
 echo "Starting dbus-daemon"
 exec dbus-daemon --system --nofork
-

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -2,7 +2,7 @@
 
 echo "Starting Plex Media Server."
 exec \
-	s6-setuidgid abc /bin/sh -c \
+	s6-setuidgid abc /bin/bash -c \
 	'/usr/lib/plexmediaserver/Plex\ Media\ Server'
 
 

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -2,7 +2,7 @@
 
 echo "Starting Plex Media Server."
 exec \
-	s6-setuidgid abc /bin/bash -c \
+	s6-setuidgid abc /bin/sh -c \
 	'/usr/lib/plexmediaserver/Plex\ Media\ Server'
 
 

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -1,6 +1,8 @@
 #!/usr/bin/with-contenv bash
 
 echo "Starting Plex Media Server."
-exec s6-setuidgid abc /bin/sh -c 'LD_LIBRARY_PATH=/usr/lib/plexmediaserver /usr/lib/plexmediaserver/Plex\ Media\ Server'
+exec \
+	s6-setuidgid abc /bin/bash -c \
+	'/usr/lib/plexmediaserver/Plex\ Media\ Server'
 
 

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -1,5 +1,6 @@
 #!/usr/bin/with-contenv bash
 
 echo "Starting Plex Media Server."
-exec s6-setuidgid abc /usr/sbin/start_pms
+exec s6-setuidgid abc /bin/sh -c 'LD_LIBRARY_PATH=/usr/lib/plexmediaserver /usr/lib/plexmediaserver/Plex\ Media\ Server'
+
 

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -4,5 +4,3 @@ echo "Starting Plex Media Server."
 exec \
 	s6-setuidgid abc /bin/bash -c \
 	'/usr/lib/plexmediaserver/Plex\ Media\ Server'
-
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ possibly alleviate issues with usermod chowning home folder causing container to "hang"
+ use same startup line as pms docker
+ use plex environment variables purloined from pms docker
+ chown /config and /config/* non-recursively in init