### PR TITLE
don't use LD_LIBRARY_PATH as env, interferes with ssl setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="/config/Library/Application Support" 
 PLEX_MEDIA_SERVER_HOME="/usr/lib/plexmediaserver" \
 PLEX_MEDIA_SERVER_INFO_DEVICE=docker \
 PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS="6" \
-PLEX_MEDIA_SERVER_USER=abc \
-LD_LIBRARY_PATH="/usr/lib/plexmediaserver:$LD_LIBRARY_PATH"
+PLEX_MEDIA_SERVER_USER=abc
 
 # install packages
 RUN \

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -3,4 +3,4 @@
 echo "Starting Plex Media Server."
 exec \
 	s6-setuidgid abc /bin/bash -c \
-	'/usr/lib/plexmediaserver/Plex\ Media\ Server'
+	'LD_LIBRARY_PATH=/usr/lib/plexmediaserver /usr/lib/plexmediaserver/Plex\ Media\ Server'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ using LD_LIBRARY_PATH as an env variable stops system ssl working and fails wget etc on updates