### PR TITLE
Write permissions for hardware transcoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN \
  dpkg -i /tmp/plexmediaserver.deb && \
  echo "**** change abc home folder to fix plex hanging at runtime with usermod ****" && \
  usermod -d /app abc && \
+ usermod -G video abc && \
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN \
  dpkg -i /tmp/plexmediaserver.deb && \
  echo "**** change abc home folder to fix plex hanging at runtime with usermod ****" && \
  usermod -d /app abc && \
- usermod -G video abc && \
+ chmod -fR 777 /dev/dri || echo "*** hardware transcoding will not be possible ****" && \
+ 
  echo "**** cleanup ****" && \
  apt-get clean && \
  rm -rf \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
Add the user to the 'video' group.

To allow hardware transcoding on plex /dev/dri needs to be writable.

The video group has write permissions of this folder.

##  Thanks, team linuxserver.io
