### PR TITLE
Add Docker-Compose configuration w/ docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Directories used to store data when using docker-compose
+data/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
     uid=1001(dockeruser) gid=1001(dockergroup) groups=1001(dockergroup)
 ```
 
+## Docker-Compose
+
+Docker-Compose can also be used to bring up a plex service in one command, while keeping your data in the host filesystem for easy access and interfacing.
+
+```Bash
+docker-compose up -d
+```
+
+### Changing the Version
+
+Edit the `environment-vars.env` file to choose the version for the plex server.
+
+### Update with Docker-Compose
+
+Update docker-compose by running `docker-compose restart` to update the plex server container.
+
 ## Setting up the application
 Webui can be found at `<your-ip>:32400/web`
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '3.7'
+services:
+
+    # To use the pre-built image, comment out the lines between `build:` and `restart:`.
+    # docker-compose will default to building an image rather than downloading one.
+    app:
+        image: linuxserver/plex:public # Switch to :latest for more fast paced updates
+        build:
+            context: ./
+            dockerfile: Dockerfile
+            args:
+                build_date: $date
+                version: custom
+        restart: unless-stopped
+        networks:
+            - net
+        # The left column is the host port used, the right column is inside the docker container
+        ports:
+            - "32400:32400"
+            - "32400:32400/udp"
+            - "32469:32469"
+            - "32469:32469/udp"
+            - "5353:5353/udp"
+            - "1900:1900/udp"
+        volumes:
+            - "./data/plex-config:/config"
+            - "./data/plex-tvshows:/data/tvshows"
+            - "./data/plex-movies:/data/movies"
+            - "./data/plex-transcode:/transcode"
+        env_file: ./environment-vars.env
+
+networks:
+    net:

--- a/environment-vars.env
+++ b/environment-vars.env
@@ -1,0 +1,5 @@
+# Change this to match your timezone
+TZ=America\Los_Angeles
+
+# Change this to the version of plex server you want to update to
+VERSION=public


### PR DESCRIPTION
I think docker-compose is even one step easier to maintain thank docker cli apps. So I wrote a docker-compose script for your container. Would really love to share it here. Cheers!

I've included a `data/` directory in the root of the repo to store the data folders for the plex server. I don't like assuming anything about my customer's environment for filesystem, and I like to keep my data with my configurations. This can be changed if necessary.

I also split the environment variables out into their own file. This is purely out of habit honestly, but I think it's good practice.

I included an isolated network for the container and only mapped out the required ports rather than binding to the host like recommended in the `README.md`. It's impossible to scale multiple services this way and I believe it's poor security practice. Also this makes it simpler to run the service behind a reverse proxy such as Caddy in another container.

The only other problem I see is the `version`. To be honest I've only used `3.7` because it's the latest and those are the docs I was reading. If I should step it down to `2.2` or something I certainly can.