### PR TITLE
adding update exit logic on docker versioning

### DIFF
--- a/root/etc/cont-init.d/60-plex-update
+++ b/root/etc/cont-init.d/60-plex-update
@@ -10,6 +10,12 @@ elif [[ "${ARCH}" == "aarch64" ]]; then
         exit 0
 fi
 
+# If docker manages versioning exit
+if [ "${VERSION}" ] && [ "${VERSION}" == 'docker' ]; then
+	echo "Docker is used for verisoning skip update check"
+	exit 0
+fi
+
 # test if plex is installed and try re-pulling latest if not
 if (dpkg --get-selections plexmediaserver | grep -wq "install"); then
 :


### PR DESCRIPTION
This got lost in the merge when we reverted the update logic for the initial release.