### PR TITLE
Remove duplicate ENV.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs, thelamer"
 
 #Add needed nvidia environment variables for https://github.com/NVIDIA/nvidia-docker
-ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 ENV NVIDIA_DRIVER_CAPABILITIES="all"
 
 # global environment settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs, thelamer"
 
 #Add needed nvidia environment variables for https://github.com/NVIDIA/nvidia-docker
+ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 ENV NVIDIA_DRIVER_CAPABILITIES="all"
 
 # global environment settings


### PR DESCRIPTION
No need for both of those, I'm personally not in favour of adding `NVIDIA_VISIBLE_DEVICES` as an ENV as we would be forced to set it to either `0` or `all` both of which could cause a hard lock on the end user server if they're using a GPU in a VM.  I think that should be an active decision.