### PR TITLE
fix for pid removal on startup

### DIFF
--- a/root/etc/cont-init.d/40-chown-files
+++ b/root/etc/cont-init.d/40-chown-files
@@ -17,7 +17,7 @@ fi
 
 # remove plex pid after unclean stop
 [[ -f "/config/Library/Application Support/Plex Media Server/plexmediaserver.pid" ]] && \
-  rm /config/Library/Application Support/Plex Media Server/plexmediaserver.pid
+  rm -f "/config/Library/Application Support/Plex Media Server/plexmediaserver.pid"
 
 # permissions (non-recursive) on config root and folders
 chown abc:abc \


### PR DESCRIPTION
Need the path in quotes due to spaces in the path. Added the force flag. 