### PR TITLE
Fixing a curl command that was broken in 60-plex-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **22.03.19:** - Fix update logic for `VERSION=public`.
 * **14.03.19:** - Switch to new api endpoints, enable beta (plex pass) updates for armhf and aarch64.
 * **15.02.19:** - Clean up plex pid after unclean stop.
 * **11.02.19:** - Fix nvidia variables, add device variables.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -82,6 +82,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "22.03.19:", desc: "Fix update logic for `VERSION=public`." }
   - { date: "14.03.19:", desc: "Switch to new api endpoints, enable beta (plex pass) updates for armhf and aarch64." }
   - { date: "15.02.19:", desc: "Clean up plex pid after unclean stop." }
   - { date: "11.02.19:", desc: "Fix nvidia variables, add device variables." }

--- a/root/etc/cont-init.d/60-plex-update
+++ b/root/etc/cont-init.d/60-plex-update
@@ -100,7 +100,7 @@ if [[ "${VERSION,,}" = latest ]] || [[ "${VERSION,,}" = plexpass ]] || [[ "$PLEX
   fi
 REMOTE_VERSION=$(curl -s "https://plex.tv/downloads/details/5?distro=debian&build=linux-${PLEX_URL_ARCH}&channel=8&X-Plex-Token=$PLEX_TOKEN"| grep -oP 'version="\K[^"]+' | tail -n 1 )
 elif [[ "${VERSION,,}" = public ]]; then
-REMOTE_VERSION=curl -sX GET 'https://plex.tv/api/downloads/5.json' | jq -r '.computer.Linux.version'
+REMOTE_VERSION=$(curl -sX GET 'https://plex.tv/api/downloads/5.json' | jq -r '.computer.Linux.version')
 else
 REMOTE_VERSION="${VERSION}"
 fi


### PR DESCRIPTION
Was getting an error when a variable was being set by running a command. Surrounded it so that BASH would know to run it.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

