### PR TITLE
WIP: Find unbuffered devices for video group permissions

### DIFF
--- a/root/etc/cont-init.d/50-gid-video
+++ b/root/etc/cont-init.d/50-gid-video
@@ -3,13 +3,15 @@
 # check for the existence of a video and/or tuner device
 if [ -e /dev/dri ] || [ -e /dev/dvb ]; then
 	if [ -e /dev/dri ]; then
-		VIDEO_GID=$(stat -c '%g' /dev/dri/* | grep -v '^0$' | head -n 1)
+		VIDEO_GID=$(stat -c '%g' "$(find /dev/dri -type c -print -quit)")
 	else
-		VIDEO_GID=$(stat -c '%g' /dev/dvb/* | grep -v '^0$' | head -n 1)
+		VIDEO_GID=$(stat -c '%g' "$(find /dev/dvb -type c -print -quit)")
 	fi
 	# just add abc to root if stuff in dri/dvb is root owned
-	if [ -z "${VIDEO_GID}" ]; then
+	if [ "${VIDEO_GID}" == "0" ]; then
 		usermod -a -G root abc
+		exit 0
+	elif [ -z "${VIDEO_GID}" ]; then
 		exit 0
 	fi
 else


### PR DESCRIPTION
Using `find` with `-type c` will find "character (unbuffered) special" which is what `/dev/dri` and `/dev/dvb` devices show up as (confirmed via the full output of `stat /dev/dri/*`). This should be slightly more accurate than just filtering out things owned by the root group (which is what the `grep` is currently doing). This would mean that `VIDEO_GID` can return `0` (root) and should be handled specifically rather than anytime `VIDEO_GID` is unset (which could mean `/dev/dri` and `/dev/dvb` are not present).

Ref: http://man7.org/linux/man-pages/man1/find.1.html search: `character (unbuffered) special`

Using `find` with `-print -quit` will find the first result and then stop iterating through results rather than how the current code pipes to `head -n 1` which finds all results and then filters to only the first one. This change is kind of trivial, but with the use of `find` on the point above this is just a minor improvement rather than using `find /dev/dri -type c | head -n 1`.

Note: not using `-print0` with `find` because of this https://lists.gnu.org/archive/html/bug-bash/2016-09/msg00015.html (it emits a warning).

I have labeled this PR WIP as I have not yet tested building the image with these changes. The logic is sound and the changed commands run outside a container without issue. I can find some time to build it and run it if needed.