### PR TITLE
Fix url for plex-pass download

### DIFF
--- a/root/etc/cont-init.d/60-plex-update
+++ b/root/etc/cont-init.d/60-plex-update
@@ -98,7 +98,7 @@ if [[ "${VERSION,,}" = latest ]] || [[ "${VERSION,,}" = plexpass ]] || [[ "$PLEX
   elif [[ "${PLEX_ARCH}" = arm64 ]]; then
     PLEX_URL_ARCH="aarch64"
   fi
-REMOTE_VERSION=$(curl -s "https://plex.tv/downloads/details/5?distro=debian&build=linux-${PLEX_URL_ARCH}&channel=8&X-Plex-Token=$PLEX_TOKEN"| grep -oP 'version="\K[^"]+' | tail -n 1 )
+REMOTE_VERSION=$(curl -s "https://plex.tv/downloads/latest/5?distro=debian&build=linux-${PLEX_URL_ARCH}&channel=8&X-Plex-Token=$PLEX_TOKEN"| grep -oP 'version="\K[^"]+' | tail -n 1 )
 elif [[ "${VERSION,,}" = public ]]; then
 REMOTE_VERSION=$(curl -sX GET 'https://plex.tv/api/downloads/5.json' | jq -r '.computer.Linux.version')
 else


### PR DESCRIPTION
## Description:
It looks like the URL for plex-pass downloads have changed and update script is no longer working. Fixed to the updated url.

## Benefits of this PR and context:
See description

## How Has This Been Tested?
I just tested the fixed URL

## Source / References:
N/A
