### PR TITLE
Force wget to use IPv4 while updating Plex to fix issue for dual stack environments

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-plex-update/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-plex-update/run
@@ -112,7 +112,7 @@ fi
 
 echo "Atempting to upgrade to: $REMOTE_VERSION"
 rm -f /tmp/plexmediaserver_*.deb
-wget -nv -P /tmp \
+wget --inet4-only -nv -P /tmp \
     "${PLEX_DOWNLOAD}/${REMOTE_VERSION}/debian/plexmediaserver_${REMOTE_VERSION}_${PLEX_ARCH}.deb"
 last=$?
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-plex/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

I recently switched to a dual-stack setup so I can utilise the servers IPv6 address(es).
In Kubernetes, this requires all pods and services to use IPv6 as well, which is when I ran into issues when applying the `latest` value to the `VERSION` env.

Trouble is that wget seems to be unable to use IPv4 if IPv6 is available but doesn't work.

While DNS resolution works fine and downloading it on the host does as well, it doesn't work inside the pod.

The `curl` commands inside the `update` script work fine as well from what I can tell, it's just wget that's unhappy.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

This PR applies the `--inet4-only` parameter to wget, thereby fixing the issue for dual-stack environments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By creating a fork, building a container with the change and trying the exact same config with my newly created image.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
