### PR TITLE
Fix ordering of options for lsiown

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-plex-chown/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-plex-chown/run
@@ -12,7 +12,7 @@ PUID=${PUID:-911}
 if [[ ! "$(stat -c %u /config/Library)" == "${PUID}" ]]; then
     echo "Change in ownership detected, please be patient while we chown existing files"
     echo "This could take some time"
-    lsiown abc:abc -R \
+    lsiown -R abc:abc \
         /config/Library
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-plex/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Fixes the ordering of options for lsiown when fixing the permissions for `/config/Library`.

## Benefits of this PR and context:
Actually corrects the permissions for `/config/Library`.

## How Has This Been Tested?
Tested by calling lsiown manually with both variants to see that the permissions get applied recursively with the fix and not without it.


## Source / References:
N/A
